### PR TITLE
Add MetadataStore class

### DIFF
--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -4,6 +4,7 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 from .cache import CacheStore
+from .metadata import BaseMetadataStore, MemoryMetadataStore
 from .registry import registry
 from .serializers import pick_serializer
 

--- a/funnel/metadata.py
+++ b/funnel/metadata.py
@@ -1,0 +1,37 @@
+import abc
+import typing
+
+import pandas as pd
+import pydantic
+
+
+@pydantic.dataclasses.dataclass
+class BaseMetadataStore(abc.ABC):
+    readonly: bool = False
+    index: str = 'key'
+    required_columns: typing.ClassVar[typing.List[str]] = [
+        'key',
+        'serializer',
+        'load_kwargs',
+        'dump_kwargs',
+    ]
+
+    @abc.abstractmethod
+    def put(self, key, value):
+        ...
+
+    @abc.abstractmethod
+    def get(self, key):
+        ...
+
+
+@pydantic.dataclasses.dataclass
+class MemoryMetadataStore(BaseMetadataStore):
+    def __post_init_post_parse__(self):
+        self.df = pd.DataFrame(columns=self.required_columns).set_index(self.index)
+
+    def put(self, key: str, value):
+        self.df.loc[key] = value
+
+    def get(self, key: str):
+        return self.df.loc[key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ dask[complete]
 xarray
 zarr
 netcdf4
-intake-esm>=2020.5.1
 pydantic
 catalogue
 fsspec

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=funnel
-known_third_party=catalogue,fsspec,pkg_resources,pydantic,pytest,setuptools,xarray
+known_third_party=catalogue,fsspec,pandas,pkg_resources,pydantic,pytest,setuptools,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import pytest
+
+from funnel import MemoryMetadataStore
+
+
+@pytest.mark.parametrize(
+    'key, value', [('test', {'serializer': 'xarray.netcdf', 'load_kwargs': {}, 'dump_kwargs': {}})]
+)
+def test_memory_metadata_store(key, value):
+    ms = MemoryMetadataStore()
+    assert isinstance(ms.df, pd.DataFrame)
+
+    ms.put(key, value)
+    results = ms.get(key)
+    assert isinstance(results, pd.Series)
+
+    assert results.to_dict() == value


### PR DESCRIPTION
Towards #11, #1.

This PR implements a minimal skeleton for the _artifact DataBase_. As I mentioned in #11, this object is low-level i.e. we should have a high-level object (funnel.Funnel) that will combine the `CacheStore` and the `MetadataStore`. With access to this high-level object, the user rarely would need to access these two low-level objects. I'm going to implement this in a separate PR. 